### PR TITLE
Clean noodle code

### DIFF
--- a/dist/RuleFromFS.js
+++ b/dist/RuleFromFS.js
@@ -1,4 +1,13 @@
 "use strict";
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) if (e.indexOf(p[i]) < 0)
+            t[p[i]] = s[p[i]];
+    return t;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 const lodash_1 = require("lodash");
 const Path = require("path");
@@ -47,16 +56,14 @@ exports.fsToRuleData = ({ id, metadata, path, ruleName, source, sourcePath }) =>
     }
     const documentation = (source in constants_1.DOCS ? constants_1.DOCS[source] : '')
         .replace(new RegExp(constants_1.RULE_PATTERN, 'g'), ruleName);
-    const meta = metadata ? metadata : { ruleName: ruleName };
+    const _a = metadata ? metadata : {}, { ruleName: metaRuleName } = _a, meta = __rest(_a, ["ruleName"]);
     if (!meta.options) {
         delete meta.options;
         delete meta.optionsDescription;
         delete meta.optionExamples;
     }
-    if (meta.ruleName !== ruleName) {
-        console.log('mismatching ruleName from file and metadata.ruleName:', { ruleName, ['metadata.ruleName']: meta.ruleName });
-        // we expect this mismatch to be not by intention, so get rid of it
-        delete meta.ruleName;
+    if (metaRuleName && metaRuleName !== ruleName) {
+        console.log('mismatching ruleName from file and metadata.ruleName:', { ruleName, ['metadata.ruleName']: metaRuleName });
     }
     return Object.assign({ id }, meta, (documentation && { documentation }), { path,
         ruleName,

--- a/dist/RuleFromFS.js
+++ b/dist/RuleFromFS.js
@@ -1,0 +1,73 @@
+"use strict";
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) if (e.indexOf(p[i]) < 0)
+            t[p[i]] = s[p[i]];
+    return t;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const lodash_1 = require("lodash");
+const Path = require("path");
+// tslint:disable-next-line:no-submodule-imports
+const rules_1 = require("tslint/lib/rules");
+const constants_1 = require("./constants");
+exports.isRuleFromFS = (r) => r !== undefined;
+exports.pathToRuleFromFS = (baseDir, req = require) => (path) => {
+    let stripped;
+    try {
+        // tslint:disable-next-line:no-non-null-assertion
+        stripped = /\/(\w+)Rule\..*/.exec(path)[1];
+    }
+    catch (error) {
+        console.log(path, error);
+        return;
+    }
+    // kebabCase from ladash is not compatible with tslint's name conversion
+    // so we need to remove the '-' sign before and after the 11
+    // that are added by kebabCase for all the
+    // react-a11y-* rules from tslint-microsoft-contrib
+    const ruleName = lodash_1.kebabCase(stripped).replace(/-11-/, '11');
+    const relativePath = path.replace(baseDir, `.`);
+    const paths = relativePath.split(Path.sep);
+    const indexOfSource = paths.lastIndexOf(constants_1.NODE_MODULES) + 1;
+    const isInNodeModules = indexOfSource > 0;
+    const sourcePath = isInNodeModules ?
+        paths.slice(0, indexOfSource + 1).join(Path.sep) : '.';
+    const source = Path.basename(isInNodeModules ? sourcePath : baseDir);
+    // tslint:disable-next-line:non-literal-require
+    const { Rule } = req(path);
+    if (!(Rule && Rule instanceof rules_1.AbstractRule.constructor))
+        return;
+    return {
+        ruleName,
+        source,
+        path: relativePath,
+        metadata: Rule.metadata,
+        sourcePath,
+        id: `${sourcePath}:${ruleName}`
+    };
+};
+exports.fsToRuleData = (_a) => {
+    var { metadata, ruleName, source, sourcePath } = _a, data = __rest(_a, ["metadata", "ruleName", "source", "sourcePath"]);
+    if (!metadata) {
+        console.log('no metadata found in rule', sourcePath, ruleName);
+    }
+    const documentation = (source in constants_1.DOCS ? constants_1.DOCS[source] : '')
+        .replace(new RegExp(constants_1.RULE_PATTERN, 'g'), ruleName);
+    const meta = metadata ? metadata : { ruleName: ruleName };
+    if (!meta.options) {
+        delete meta.options;
+        delete meta.optionsDescription;
+        delete meta.optionExamples;
+    }
+    if (meta.ruleName !== ruleName) {
+        console.log('mismatching ruleName from file and metadata.ruleName:', { ruleName, ['metadata.ruleName']: meta.ruleName });
+        // we expect this mismatch to be not by intention, so get rid of it
+        delete meta.ruleName;
+    }
+    return Object.assign({ ruleName,
+        source }, data, meta, (documentation && { documentation }), { sourcePath });
+};

--- a/dist/RuleFromFS.js
+++ b/dist/RuleFromFS.js
@@ -1,13 +1,4 @@
 "use strict";
-var __rest = (this && this.__rest) || function (s, e) {
-    var t = {};
-    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
-        t[p] = s[p];
-    if (s != null && typeof Object.getOwnPropertySymbols === "function")
-        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) if (e.indexOf(p[i]) < 0)
-            t[p[i]] = s[p[i]];
-    return t;
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 const lodash_1 = require("lodash");
 const Path = require("path");
@@ -42,16 +33,15 @@ exports.pathToRuleFromFS = (baseDir, req = require) => (path) => {
     if (!(Rule && Rule instanceof rules_1.AbstractRule.constructor))
         return;
     return {
+        id: `${sourcePath}:${ruleName}`,
+        metadata: Rule.metadata,
+        path: relativePath,
         ruleName,
         source,
-        path: relativePath,
-        metadata: Rule.metadata,
-        sourcePath,
-        id: `${sourcePath}:${ruleName}`
+        sourcePath
     };
 };
-exports.fsToRuleData = (_a) => {
-    var { metadata, ruleName, source, sourcePath } = _a, data = __rest(_a, ["metadata", "ruleName", "source", "sourcePath"]);
+exports.fsToRuleData = ({ id, metadata, path, ruleName, source, sourcePath }) => {
     if (!metadata) {
         console.log('no metadata found in rule', sourcePath, ruleName);
     }
@@ -68,6 +58,8 @@ exports.fsToRuleData = (_a) => {
         // we expect this mismatch to be not by intention, so get rid of it
         delete meta.ruleName;
     }
-    return Object.assign({ ruleName,
-        source }, data, meta, (documentation && { documentation }), { sourcePath });
+    return Object.assign({ id }, meta, (documentation && { documentation }), { path,
+        ruleName,
+        source,
+        sourcePath });
 };

--- a/dist/RuleFromTslint.js
+++ b/dist/RuleFromTslint.js
@@ -38,9 +38,13 @@ exports.loadedToActiveRules = (rulesAvailable) => (report, rule) => {
     else {
         const { deprecationMessage, documentation, hasFix, group, source, sameName, type } = ruleData;
         const deprecated = deprecation(deprecationMessage, group);
-        report[ruleName] = Object.assign({ ruleName,
-            ruleSeverity,
-            source }, (deprecated && { deprecated }), (documentation && { documentation }), (hasFix && { hasFix }), (group && { group }), (type && { type }), (ruleArguments && { ruleArguments }), (sameName && { sameName: sameName.map(r => r.id) }));
+        report[ruleName] = Object.assign({}, (deprecated && { deprecated }), (documentation && { documentation }), (hasFix && { hasFix }), { ruleSeverity }, lodash_1.omitBy({
+            group,
+            type,
+            ruleArguments,
+            sameName: sameName ? sameName.map(r => r.id) : []
+        }, lodash_1.isEmpty), { ruleName,
+            source });
     }
     return report;
 };

--- a/dist/RuleFromTslint.js
+++ b/dist/RuleFromTslint.js
@@ -1,0 +1,46 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const lodash_1 = require("lodash");
+const tslint_1 = require("tslint");
+// tslint:disable-next-line:no-submodule-imports
+const configuration_1 = require("tslint/lib/configuration");
+const ExtendedMetadata_1 = require("./ExtendedMetadata");
+exports.loadRulesFromConfig = (tslint_loadConfig = configuration_1.loadConfigurationFromPath, tslint_loadRules = tslint_1.loadRules) => (configFile) => {
+    const rulesFromConfig = tslint_loadConfig(configFile, configFile);
+    const namedRules = [];
+    rulesFromConfig.rules.forEach((option, key) => {
+        // console.log(key, JSON.stringify(option));
+        namedRules.push(Object.assign({}, option, { ruleName: key }));
+    });
+    return lodash_1.sortBy(tslint_loadRules(namedRules, rulesFromConfig.rulesDirectory), 'ruleName');
+};
+/**
+ sometimes deprecation message is an empty string, which still means deprecated,
+ tslint-microsoft-contrib sets the group metadata to 'Deprecated' instead
+ */
+const deprecation = (deprecationMessage, group) => {
+    if (deprecationMessage !== undefined) {
+        return deprecationMessage || true;
+    }
+    return group === ExtendedMetadata_1.DEPRECATED;
+};
+exports.loadedToActiveRules = (rulesAvailable) => (report, rule) => {
+    const { ruleName, ruleArguments, ruleSeverity } = rule.getOptions();
+    const ruleData = rulesAvailable[ruleName];
+    if (!ruleData) {
+        console.log('Rule not found as available', ruleName);
+        report[ruleName] = {
+            ruleName,
+            ruleArguments,
+            ruleSeverity
+        };
+    }
+    else {
+        const { deprecationMessage, documentation, hasFix, group, source, sameName, type } = ruleData;
+        const deprecated = deprecation(deprecationMessage, group);
+        report[ruleName] = Object.assign({ ruleName,
+            ruleSeverity,
+            source }, (deprecated && { deprecated }), (documentation && { documentation }), (hasFix && { hasFix }), (group && { group }), (type && { type }), (ruleArguments && { ruleArguments }), (sameName && { sameName: sameName.map(r => r.id) }));
+    }
+    return report;
+};

--- a/dist/constants.js
+++ b/dist/constants.js
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.RULE_PATTERN = '{RULE}';
+exports.NODE_MODULES = 'node_modules';
+exports.TSLINT = `tslint`;
+// tslint:disable-next-line:no-var-requires
+exports.DOCS = require('../rules.docs.json');

--- a/dist/report.js
+++ b/dist/report.js
@@ -1,164 +1,50 @@
 "use strict";
-var __rest = (this && this.__rest) || function (s, e) {
-    var t = {};
-    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
-        t[p] = s[p];
-    if (s != null && typeof Object.getOwnPropertySymbols === "function")
-        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) if (e.indexOf(p[i]) < 0)
-            t[p[i]] = s[p[i]];
-    return t;
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs = require("fs-extra");
 const glob = require("glob");
 const lodash_1 = require("lodash");
 const Path = require("path");
-const tslint_1 = require("tslint");
-// tslint:disable-next-line:no-submodule-imports
-const configuration_1 = require("tslint/lib/configuration");
-const ExtendedMetadata_1 = require("./ExtendedMetadata");
-const RULE_PATTERN = '{RULE}';
-const DOCS = {
-    tslint: `https://palantir.github.io/tslint/rules/${RULE_PATTERN}`,
-    'tslint-eslint-rules': `https://eslint.org/docs/rules/${RULE_PATTERN}`,
-    'tslint-microsoft-contrib': 'https://github.com/Microsoft/tslint-microsoft-contrib#supported-rules',
-    'tslint-react': 'https://github.com/palantir/tslint-react#rules',
-    'bm-tslint-rules': 'https://github.com/bettermarks/bm-tslint-rules#rules'
-};
-const NODE_MODULES = 'node_modules';
+const constants_1 = require("./constants");
+const RuleFromFS_1 = require("./RuleFromFS");
+const RuleFromTslint_1 = require("./RuleFromTslint");
+const sources_1 = require("./sources");
 const CWD = process.cwd();
-// const ruleSets = walk(process.cwd(), {nodir: true, filter: findRuleSets}).map(item => item.path);
-const ruleId = ({ ruleName, sourcePath }) => `${sourcePath}:${ruleName}`;
-const rules = glob.sync('*Rule.js', {
-    nodir: true, matchBase: true, absolute: true, ignore: ['**/tslint/lib/language/**', '**/Rule.js']
-});
-const rulesAvailable = rules.reduce(
-// tslint:disable-next-line:cyclomatic-complexity
-(dict, path) => {
-    let stripped;
-    try {
-        // tslint:disable-next-line:no-non-null-assertion
-        stripped = /\/(\w+)Rule\..*/.exec(path)[1];
-    }
-    catch (error) {
-        console.log(path, error);
-        return dict;
-    }
-    // kebabCase from ladash is not compatible with tslint's name conversion
-    // so we need to remove the '-' sign before and after the 11
-    // that are added by kebabCase for all the
-    // react-a11y-* rules from tslint-microsoft-contrib
-    const ruleName = lodash_1.kebabCase(stripped).replace(/-11-/, '11');
-    const relativePath = path.replace(CWD, `.`);
-    const paths = relativePath.split(Path.sep);
-    const indexOfSource = paths.lastIndexOf(NODE_MODULES) + 1;
-    const inInNodeModules = indexOfSource > 0;
-    const sourcePath = inInNodeModules ?
-        paths.slice(0, indexOfSource + 1).join(Path.sep) : '.';
-    const source = Path.basename(inInNodeModules ? sourcePath : CWD);
-    // tslint:disable-next-line:non-literal-require
-    const { Rule } = require(path);
-    if (!(Rule && Rule instanceof tslint_1.Rules.AbstractRule.constructor))
-        return dict;
-    if (!Rule.metadata) {
-        console.log('no metadata found in rule', sourcePath, ruleName);
-    }
-    const documentation = (source in DOCS ? DOCS[source] : '')
-        .replace(new RegExp(RULE_PATTERN, 'g'), ruleName);
-    const metadata = Rule.metadata ? Rule.metadata : { ruleName: ruleName };
-    if (!metadata.options) {
-        delete metadata.options;
-        delete metadata.optionsDescription;
-        delete metadata.optionExamples;
-    }
-    const data = Object.assign({}, metadata, (documentation && { documentation }), { path: relativePath, source,
-        sourcePath });
+const rules = glob
+    // everything ending with Rule.js could be a tslint rule
+    .sync('*Rule.js', {
+    cwd: CWD, nodir: true, matchBase: true, absolute: true, ignore: [
+        // there are some problematic exceptions
+        '**/tslint/lib/language/**', '**/Rule.js'
+    ]
+})
+    .map(RuleFromFS_1.pathToRuleFromFS(CWD))
+    .filter(RuleFromFS_1.isRuleFromFS)
+    .map(RuleFromFS_1.fsToRuleData);
+const sourcesOrder = sources_1.createSourcesOrder(rules);
+const sources = sourcesOrder.reduce(sources_1.tupleToSources(), {});
+const rulesAvailable = lodash_1.sortBy(rules, ['ruleName', sources_1.indexInSourceOrder(sourcesOrder)]).reduce((dict, rule) => {
+    const { ruleName } = rule;
     const existing = dict[ruleName];
     if (existing) {
-        // there is another rule with the same name
-        const currentId = ruleId(data);
-        const existingId = ruleId(existing);
-        if (source === 'tslint') {
-            // the current one wins because custom rules can not override tslint rules
-            data.sameName = [...(existing.sameName ? existing.sameName : []), existingId];
-            dict[existingId] = existing;
-            dict[ruleName] = data;
+        if (existing.source !== constants_1.TSLINT && !existing.sameName) {
+            console.log(`rule name '${ruleName}' available from different sources (first extend wins)`);
         }
-        else {
-            // non deterministic which one wins
-            if (existing.source !== 'tslint') {
-                console.log(`rule name '${ruleName}' available from different sources (first extend wins)`);
-            }
-            // we keep the existing one in the dict, point to the conflict
-            // and only store the current one under its ID
-            existing.sameName = [...(existing.sameName ? existing.sameName : []), currentId];
-            dict[currentId] = data;
-        }
+        existing.sameName = [...(existing.sameName ? existing.sameName : []), rule];
     }
     else {
-        dict[ruleName] = data;
+        dict[ruleName] = rule;
     }
     return dict;
 }, {});
-const reportAvailable = {};
-const sources = {};
-lodash_1.sortedUniqBy(lodash_1.values(rulesAvailable), 'sourcePath')
-    .forEach(({ source, sourcePath }) => {
-    const { _from, _resolved, bugs, deprecated, description, homepage, main, peerDependencies } = fs.readJsonSync(Path.join(sourcePath, 'package.json'));
-    sources[sourcePath] = {
-        _from,
-        _resolved,
-        bugs,
-        deprecated,
-        description,
-        docs: source in DOCS ? DOCS[source] : 'unknown',
-        homepage,
-        main,
-        name: source,
-        path: sourcePath,
-        peerDependencies
-    };
-});
-// reportAvailable.$sources = sources;
-lodash_1.sortBy(Object.keys(rulesAvailable)).forEach(key => {
-    const rule = Object.assign({}, rulesAvailable[key]);
-    const { ruleName } = rule, ruleData = __rest(rule, ["ruleName"]);
-    reportAvailable[key] = ruleData;
-});
 console.log(`${rules.length} rules available from ${Object.keys(sources).length} sources:`, JSON.stringify(Object.keys(sources), undefined, 2));
 fs.writeJSONSync('tslint.report.sources.json', sources, { spaces: 2 });
-fs.writeJSONSync('tslint.report.available.json', reportAvailable, { spaces: 2 });
-// const tslintJson = findConfiguration('tslint.json').results;
-const configFile = Path.join(CWD, 'tslint.json');
-const rulesFromConfig = configuration_1.loadConfigurationFromPath(configFile, configFile);
-const namedRules = [];
-rulesFromConfig.rules.forEach((option, key) => {
-    // console.log(key, JSON.stringify(option));
-    namedRules.push(Object.assign({}, option, { ruleName: key }));
-});
-const loadedRules = tslint_1.loadRules(namedRules, rulesFromConfig.rulesDirectory);
-const report = {};
-// tslint:disable-next-line:cyclomatic-complexity
-lodash_1.sortBy(loadedRules, 'ruleName').forEach((rule) => {
-    const { ruleName, ruleArguments, ruleSeverity } = rule.getOptions();
-    if (!(ruleName in rulesAvailable)) {
-        report[ruleName] = {
-            ruleArguments,
-            ruleSeverity
-        };
-        console.log('Rule not found as available', ruleName);
-        return;
-    }
-    const ruleData = rulesAvailable[ruleName];
-    const { deprecationMessage, documentation, hasFix, group, source, sameName, type } = ruleData;
-    // sometimes deprecation message is an empty string, which still means deprecated,
-    // tslint-microsoft-contrib sets the group metadata to 'Deprecated' instead
-    const deprecated = deprecationMessage !== undefined || (group && group === ExtendedMetadata_1.DEPRECATED);
-    if (deprecated) {
-        console.warn(`WARNING: The deprecated rule '${ruleName}' from '${source}' is active.`);
-    }
-    report[ruleName] = Object.assign({}, (deprecated && { deprecated: deprecationMessage || true }), (documentation && { documentation }), (hasFix && { hasFix }), (group && { group }), (type && { type }), (ruleArguments && ruleArguments.length && { ruleArguments }), { ruleSeverity,
-        source }, (source !== 'tslint' && sameName && sameName.length && { sameName }));
+fs.writeJSONSync('tslint.report.available.json', rulesAvailable, { spaces: 2 });
+const loadedRules = RuleFromTslint_1.loadRulesFromConfig()(Path.join(CWD, 'tslint.json'));
+const report = loadedRules.reduce(RuleFromTslint_1.loadedToActiveRules(rulesAvailable), {});
+lodash_1.values(report)
+    .filter(r => r.deprecated)
+    .forEach(({ ruleName, source }) => {
+    console.warn(`WARNING: The deprecated rule '${ruleName}' from '${source}' is active.`);
 });
 fs.writeJSONSync('tslint.report.active.json', report, { spaces: 2 });
 console.log('active rules:', loadedRules.length);

--- a/dist/sources.js
+++ b/dist/sources.js
@@ -1,0 +1,37 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs-extra");
+const lodash_1 = require("lodash");
+const Path = require("path");
+const constants_1 = require("./constants");
+exports.createSourcesOrder = (rules) => {
+    const unordered = lodash_1.uniqBy(rules, r => r.source)
+        .map(r => [r.source, r.sourcePath]);
+    // TODO sort by order defined in config files? (issue #2)
+    const tslint = unordered.find(([source]) => source === constants_1.TSLINT);
+    return tslint ? [
+        tslint,
+        ...unordered.filter(it => it !== tslint)
+    ] : unordered;
+};
+exports.indexInSourceOrder = (sourcesOrder) => {
+    const sources = sourcesOrder.map(([source]) => source);
+    return r => sources.indexOf(r.source);
+};
+exports.tupleToSources = ({ readJsonSync } = fs) => (sources, [source, sourcePath]) => {
+    const { _from, _resolved, bugs, deprecated, description, homepage, main, peerDependencies } = readJsonSync(Path.join(sourcePath, 'package.json'));
+    sources[sourcePath] = {
+        _from,
+        _resolved,
+        bugs,
+        deprecated,
+        description,
+        docs: source in constants_1.DOCS ? constants_1.DOCS[source] : 'unknown',
+        homepage,
+        main,
+        name: source,
+        path: sourcePath,
+        peerDependencies
+    };
+    return sources;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-report",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-report",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "This is a utility for maintaining a tslint rule set.",
   "repository": "https://github.com/karfau/tslint-report",
   "bugs": "https://github.com/karfau/tslint-report/issues",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "main": "dist/report.js",
   "files": [
     "dist",
-    "bin"
+    "bin",
+    "rules.docs.json"
   ],
   "bin": {
     "tslint-report": "bin/tslint-report"

--- a/rules.docs.json
+++ b/rules.docs.json
@@ -1,0 +1,7 @@
+{
+  "tslint": "https://palantir.github.io/tslint/rules/{RULE}",
+  "tslint-eslint-rules": "https://eslint.org/docs/rules/{RULE}",
+  "tslint-microsoft-contrib": "https://github.com/Microsoft/tslint-microsoft-contrib#supported-rules",
+  "tslint-react": "https://github.com/palantir/tslint-react#rules",
+  "bm-tslint-rules": "https://github.com/bettermarks/bm-tslint-rules#rules"
+}

--- a/src/RuleFromFS.ts
+++ b/src/RuleFromFS.ts
@@ -45,16 +45,18 @@ export const pathToRuleFromFS = (
   if (!(Rule && Rule instanceof AbstractRule.constructor)) return;
 
   return {
+    id: `${sourcePath}:${ruleName}`,
+    metadata: Rule.metadata,
+    path: relativePath,
     ruleName,
     source,
-    path: relativePath,
-    metadata: Rule.metadata,
-    sourcePath,
-    id: `${sourcePath}:${ruleName}`
+    sourcePath
   };
 };
 
-export const fsToRuleData = ({metadata, ruleName, source, sourcePath, ...data}: RuleFromFS) => {
+export const fsToRuleData = (
+  {id, metadata, path, ruleName, source, sourcePath}: RuleFromFS
+) => {
   if (!metadata) {
     console.log('no metadata found in rule', sourcePath, ruleName);
   }
@@ -77,11 +79,12 @@ export const fsToRuleData = ({metadata, ruleName, source, sourcePath, ...data}: 
   }
 
   return {
-    ruleName,
-    source,
-    ...data,
+    id,
     ...meta,
     ...(documentation && {documentation}),
+    path,
+    ruleName,
+    source,
     sourcePath
   };
 };

--- a/src/RuleFromFS.ts
+++ b/src/RuleFromFS.ts
@@ -9,7 +9,9 @@ import {ReportData, RuleMetadata, RuleName} from './types';
 type RuleFromFS = ReportData & RuleName & {
   metadata?: any;
 };
+
 export const isRuleFromFS = (r: RuleFromFS | undefined): r is RuleFromFS => r !== undefined;
+
 export const pathToRuleFromFS = (
   baseDir: string, req = require
 ) => (

--- a/src/RuleFromFS.ts
+++ b/src/RuleFromFS.ts
@@ -1,0 +1,85 @@
+import {kebabCase} from 'lodash';
+import * as Path from 'path';
+// tslint:disable-next-line:no-submodule-imports
+import {AbstractRule} from 'tslint/lib/rules';
+
+import {DOCS, NODE_MODULES, RULE_PATTERN} from './constants';
+import {ReportData, RuleMetadata, RuleName} from './types';
+
+type RuleFromFS = ReportData & RuleName & {
+  metadata?: any;
+};
+export const isRuleFromFS = (r: RuleFromFS | undefined): r is RuleFromFS => r !== undefined;
+export const pathToRuleFromFS = (
+  baseDir: string, req = require
+) => (
+  path: string
+): RuleFromFS | undefined => {
+  let stripped;
+  try {
+    // tslint:disable-next-line:no-non-null-assertion
+    stripped = /\/(\w+)Rule\..*/.exec(path)![1];
+  } catch (error) {
+    console.log(path, error);
+    return;
+  }
+
+  // kebabCase from ladash is not compatible with tslint's name conversion
+  // so we need to remove the '-' sign before and after the 11
+  // that are added by kebabCase for all the
+  // react-a11y-* rules from tslint-microsoft-contrib
+  const ruleName = kebabCase(stripped).replace(/-11-/, '11');
+
+  const relativePath = path.replace(baseDir, `.`);
+  const paths = relativePath.split(Path.sep);
+  const indexOfSource = paths.lastIndexOf(NODE_MODULES) + 1;
+  const isInNodeModules = indexOfSource > 0;
+  const sourcePath = isInNodeModules ?
+    paths.slice(0, indexOfSource + 1).join(Path.sep) : '.';
+  const source = Path.basename(isInNodeModules ? sourcePath : baseDir);
+
+  // tslint:disable-next-line:non-literal-require
+  const {Rule} = req(path);
+  if (!(Rule && Rule instanceof AbstractRule.constructor)) return;
+
+  return {
+    ruleName,
+    source,
+    path: relativePath,
+    metadata: Rule.metadata,
+    sourcePath,
+    id: `${sourcePath}:${ruleName}`
+  };
+};
+
+export const fsToRuleData = ({metadata, ruleName, source, sourcePath, ...data}: RuleFromFS) => {
+  if (!metadata) {
+    console.log('no metadata found in rule', sourcePath, ruleName);
+  }
+  const documentation = (source in DOCS ? DOCS[source as keyof typeof DOCS] : '')
+    .replace(new RegExp(RULE_PATTERN, 'g'), ruleName);
+
+  const meta: RuleMetadata = metadata ? metadata : {ruleName: ruleName};
+  if (!meta.options) {
+    delete meta.options;
+    delete meta.optionsDescription;
+    delete meta.optionExamples;
+  }
+  if (meta.ruleName !== ruleName) {
+    console.log(
+      'mismatching ruleName from file and metadata.ruleName:',
+      {ruleName, ['metadata.ruleName']: meta.ruleName}
+    );
+    // we expect this mismatch to be not by intention, so get rid of it
+    delete meta.ruleName;
+  }
+
+  return {
+    ruleName,
+    source,
+    ...data,
+    ...meta,
+    ...(documentation && {documentation}),
+    sourcePath
+  };
+};

--- a/src/RuleFromFS.ts
+++ b/src/RuleFromFS.ts
@@ -63,19 +63,17 @@ export const fsToRuleData = (
   const documentation = (source in DOCS ? DOCS[source as keyof typeof DOCS] : '')
     .replace(new RegExp(RULE_PATTERN, 'g'), ruleName);
 
-  const meta: RuleMetadata = metadata ? metadata : {ruleName: ruleName};
+  const {ruleName: metaRuleName, ...meta}: RuleMetadata = metadata ? metadata : {};
   if (!meta.options) {
     delete meta.options;
     delete meta.optionsDescription;
     delete meta.optionExamples;
   }
-  if (meta.ruleName !== ruleName) {
+  if (metaRuleName && metaRuleName !== ruleName) {
     console.log(
       'mismatching ruleName from file and metadata.ruleName:',
-      {ruleName, ['metadata.ruleName']: meta.ruleName}
+      {ruleName, ['metadata.ruleName']: metaRuleName}
     );
-    // we expect this mismatch to be not by intention, so get rid of it
-    delete meta.ruleName;
   }
 
   return {

--- a/src/RuleFromTslint.ts
+++ b/src/RuleFromTslint.ts
@@ -1,0 +1,81 @@
+import {sortBy} from 'lodash';
+import {IOptions, IRule, loadRules, RuleSeverity} from 'tslint';
+// tslint:disable-next-line:no-submodule-imports
+import {loadConfigurationFromPath} from 'tslint/lib/configuration';
+
+import {DEPRECATED} from './ExtendedMetadata';
+import {Dict, RuleData, RuleName} from './types';
+
+export type ActiveRule = RuleName & {
+  deprecated?: string | boolean;
+  documentation?: string;
+  hasFix?: boolean;
+  ruleArguments?: any[];
+  ruleSeverity: RuleSeverity;
+  sameName?: string[];
+  source?: string;
+  group?: string;
+  type?: string;
+};
+
+export const loadRulesFromConfig = (
+  tslint_loadConfig = loadConfigurationFromPath, tslint_loadRules = loadRules
+) => (
+  configFile: string
+) => {
+  const rulesFromConfig = tslint_loadConfig(configFile, configFile);
+  const namedRules: IOptions[] = [];
+  rulesFromConfig.rules.forEach((option, key) => {
+    // console.log(key, JSON.stringify(option));
+    namedRules.push({...(option as IOptions), ruleName: key});
+  });
+  return sortBy(tslint_loadRules(namedRules, rulesFromConfig.rulesDirectory), 'ruleName');
+};
+
+/**
+ sometimes deprecation message is an empty string, which still means deprecated,
+ tslint-microsoft-contrib sets the group metadata to 'Deprecated' instead
+ */
+const deprecation = (
+  deprecationMessage: string | undefined, group: string | undefined
+): string | boolean => {
+  if (deprecationMessage !== undefined) {
+    return deprecationMessage || true;
+  }
+  return group === DEPRECATED;
+};
+
+export const loadedToActiveRules = (
+  rulesAvailable: Dict<RuleData>
+) => (
+  report: Dict<ActiveRule>, rule: IRule
+) => {
+  const {ruleName, ruleArguments, ruleSeverity} = rule.getOptions();
+  const ruleData = rulesAvailable[ruleName];
+  if (!ruleData) {
+    console.log('Rule not found as available', ruleName);
+    report[ruleName] = {
+      ruleName,
+      ruleArguments,
+      ruleSeverity
+    };
+  } else {
+    const {
+      deprecationMessage, documentation, hasFix, group, source, sameName, type
+    } = ruleData;
+    const deprecated = deprecation(deprecationMessage, group);
+    report[ruleName] = {
+      ruleName,
+      ruleSeverity,
+      source,
+      ...(deprecated && {deprecated}),
+      ...(documentation && {documentation}),
+      ...(hasFix && {hasFix}),
+      ...(group && {group}),
+      ...(type && {type}),
+      ...(ruleArguments && {ruleArguments}),
+      ...(sameName && {sameName: sameName.map(r => r.id)})
+    };
+  }
+  return report;
+};

--- a/src/RuleFromTslint.ts
+++ b/src/RuleFromTslint.ts
@@ -1,4 +1,4 @@
-import {sortBy} from 'lodash';
+import {sortBy, omitBy, isEmpty} from 'lodash';
 import {IOptions, IRule, loadRules, RuleSeverity} from 'tslint';
 // tslint:disable-next-line:no-submodule-imports
 import {loadConfigurationFromPath} from 'tslint/lib/configuration';
@@ -65,16 +65,21 @@ export const loadedToActiveRules = (
     } = ruleData;
     const deprecated = deprecation(deprecationMessage, group);
     report[ruleName] = {
-      ruleName,
-      ruleSeverity,
-      source,
       ...(deprecated && {deprecated}),
       ...(documentation && {documentation}),
       ...(hasFix && {hasFix}),
-      ...(group && {group}),
-      ...(type && {type}),
-      ...(ruleArguments && {ruleArguments}),
-      ...(sameName && {sameName: sameName.map(r => r.id)})
+      ruleSeverity,
+      ...omitBy(
+        {
+          group,
+          type,
+          ruleArguments,
+          sameName: sameName ? sameName.map(r => r.id) : []
+        },
+        isEmpty
+      ),
+      ruleName,
+      source
     };
   }
   return report;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,9 @@
+import {Dict} from './types';
+
+export const RULE_PATTERN = '{RULE}';
+export const NODE_MODULES = 'node_modules';
+export const TSLINT = `tslint`;
+
+// tslint:disable-next-line:no-var-requires
+export const DOCS: Readonly<Dict<string>> = require('../rules.docs.json');
+

--- a/src/report.ts
+++ b/src/report.ts
@@ -1,21 +1,18 @@
 import * as fs from 'fs-extra';
 import * as glob from 'glob';
-
-import {countBy, sortBy, uniqBy, values} from 'lodash';
+import {countBy, sortBy, values} from 'lodash';
 import * as Path from 'path';
-import {IOptions, IRule, loadRules} from 'tslint';
-// tslint:disable-next-line:no-submodule-imports
-import {loadConfigurationFromPath} from 'tslint/lib/configuration';
 
-import {DOCS, TSLINT} from './constants';
-import {DEPRECATED} from './ExtendedMetadata';
+import {TSLINT} from './constants';
 import {fsToRuleData, isRuleFromFS, pathToRuleFromFS} from './RuleFromFS';
-import {ActiveRule, Dict, PackageJson, RuleData, Source} from './types';
+import {ActiveRule, loadedToActiveRules, loadRulesFromConfig} from './RuleFromTslint';
+import {createSourcesOrder, indexInSourceOrder, tupleToSources} from './sources';
+import {Dict, RuleData, Source} from './types';
 
 const CWD = process.cwd();
 
 const rules: ReadonlyArray<RuleData> = glob
-  // everything ending with Rule.js could be a tslint rule
+// everything ending with Rule.js could be a tslint rule
   .sync('*Rule.js', {
     cwd: CWD, nodir: true, matchBase: true, absolute: true, ignore: [
       // there are some problematic exceptions
@@ -26,69 +23,30 @@ const rules: ReadonlyArray<RuleData> = glob
   .filter(isRuleFromFS)
   .map(fsToRuleData);
 
-export type SourceTuple = [string, string];
-const createSourcesOrder = (rules: ReadonlyArray<RuleData>): ReadonlyArray<SourceTuple> => {
-  const unordered = uniqBy(rules, r => r.source)
-    .map<SourceTuple>(r => [r.source, r.sourcePath]);
-  // TODO sort by order defined in config files? (issue #2)
-  const tslint = unordered.find(([source]) => source === TSLINT);
-
-  return tslint ? [
-    tslint, // rules from tslint take precedence
-    ...unordered.filter(it => it !== tslint)
-  ] : unordered;
-};
-
 const sourcesOrder = createSourcesOrder(rules);
-
-const tupleToSources = (
-  {readJsonSync}: Pick<typeof fs, 'readJsonSync'> = fs
-) => (
-  sources: Dict<Source>, [source, sourcePath]: SourceTuple
-) => {
-  const {
-    _from, _resolved, bugs, deprecated, description, homepage, main, peerDependencies
-  } = readJsonSync(Path.join(sourcePath, 'package.json')) as PackageJson;
-
-  sources[sourcePath] = {
-    _from,
-    _resolved,
-    bugs,
-    deprecated,
-    description,
-    docs: source in DOCS ? DOCS[source as keyof typeof DOCS] : 'unknown',
-    homepage,
-    main,
-    name: source,
-    path: sourcePath,
-    peerDependencies
-  };
-  return sources;
-};
-
 const sources = sourcesOrder.reduce<Dict<Source>>(tupleToSources(), {});
 
-const rulesAvailable = sortBy(
-  rules, ['ruleName', (r: RuleData) => sourcesOrder.findIndex(([source]) => r.source === source)])
-  .reduce<Dict<RuleData>>(
-    (dict, rule) => {
-      const {ruleName} = rule;
+const rulesAvailable = sortBy<RuleData>(
+  rules, ['ruleName', indexInSourceOrder(sourcesOrder)]
+).reduce<Dict<RuleData>>(
+  (dict, rule) => {
+    const {ruleName} = rule;
 
-      const existing = dict[ruleName];
-      if (existing) {
-        if (existing.source !== TSLINT && !existing.sameName) {
-          console.log(
-            `rule name '${ruleName}' available from different sources (first extend wins)`
-          );
-        }
-        existing.sameName = [...(existing.sameName ? existing.sameName : []), rule];
-      } else {
-        dict[ruleName] = rule;
+    const existing = dict[ruleName];
+    if (existing) {
+      if (existing.source !== TSLINT && !existing.sameName) {
+        console.log(
+          `rule name '${ruleName}' available from different sources (first extend wins)`
+        );
       }
-      return dict;
-    },
-    {}
-  );
+      existing.sameName = [...(existing.sameName ? existing.sameName : []), rule];
+    } else {
+      dict[ruleName] = rule;
+    }
+    return dict;
+  },
+  {}
+);
 
 console.log(
   `${rules.length} rules available from ${Object.keys(sources).length} sources:`,
@@ -97,67 +55,9 @@ console.log(
 fs.writeJSONSync('tslint.report.sources.json', sources, {spaces: 2});
 fs.writeJSONSync('tslint.report.available.json', rulesAvailable, {spaces: 2});
 
-const loadRulesFromConfig = (
-  tslint_loadConfig = loadConfigurationFromPath, tslint_loadRules = loadRules
-) => (
-  configFile: string
-) => {
-  const rulesFromConfig = tslint_loadConfig(configFile, configFile);
-  const namedRules: IOptions[] = [];
-  rulesFromConfig.rules.forEach((option, key) => {
-    // console.log(key, JSON.stringify(option));
-    namedRules.push({...(option as IOptions), ruleName: key});
-  });
-  return sortBy(tslint_loadRules(namedRules, rulesFromConfig.rulesDirectory), 'ruleName');
-};
-
 const loadedRules = loadRulesFromConfig()(Path.join(CWD, 'tslint.json'));
 
-/**
- sometimes deprecation message is an empty string, which still means deprecated,
- tslint-microsoft-contrib sets the group metadata to 'Deprecated' instead
-*/
-const deprecation = (
-  deprecationMessage: string | undefined, group: string | undefined
-): string | boolean => {
-  if (deprecationMessage !== undefined) {
-    return deprecationMessage || true;
-  }
-  return group === DEPRECATED;
-};
-
-const loadedToActiveRules = (report: Dict<ActiveRule>, rule: IRule) => {
-  const {ruleName, ruleArguments, ruleSeverity} = rule.getOptions();
-  const ruleData = rulesAvailable[ruleName];
-  if (!ruleData) {
-    console.log('Rule not found as available', ruleName);
-    report[ruleName] = {
-      ruleName,
-      ruleArguments,
-      ruleSeverity
-    };
-  } else {
-    const {
-      deprecationMessage, documentation, hasFix, group, source, sameName, type
-    } = ruleData;
-    const deprecated = deprecation(deprecationMessage, group);
-    report[ruleName] = {
-      ruleName,
-      ruleSeverity,
-      source,
-      ...(deprecated && {deprecated}),
-      ...(documentation && {documentation}),
-      ...(hasFix && {hasFix}),
-      ...(group && {group}),
-      ...(type && {type}),
-      ...(ruleArguments && {ruleArguments}),
-      ...(sameName && {sameName: sameName.map(r => r.id)})
-    };
-  }
-  return report;
-};
-
-const report = loadedRules.reduce<Dict<ActiveRule>>(loadedToActiveRules, {});
+const report = loadedRules.reduce<Dict<ActiveRule>>(loadedToActiveRules(rulesAvailable), {});
 
 values(report)
   .filter(r => r.deprecated)

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -1,0 +1,55 @@
+import * as fs from 'fs-extra';
+import {uniqBy} from 'lodash';
+import * as Path from 'path';
+
+import {DOCS, TSLINT} from './constants';
+import {Dict, PackageJson, RuleData, Source} from './types';
+
+/**
+ * [source, sourcePath]
+ */
+export type SourceTuple = [string, string];
+
+export const createSourcesOrder = (rules: ReadonlyArray<RuleData>): ReadonlyArray<SourceTuple> => {
+  const unordered = uniqBy(rules, r => r.source)
+    .map<SourceTuple>(r => [r.source, r.sourcePath]);
+  // TODO sort by order defined in config files? (issue #2)
+  const tslint = unordered.find(([source]) => source === TSLINT);
+
+  return tslint ? [
+    tslint, // rules from tslint take precedence
+    ...unordered.filter(it => it !== tslint)
+  ] : unordered;
+};
+
+export const indexInSourceOrder = (
+  sourcesOrder: ReadonlyArray<SourceTuple>
+): (r: RuleData) => number => {
+  const sources: ReadonlyArray<string> = sourcesOrder.map(([source]) => source);
+  return r => sources.indexOf(r.source);
+};
+
+export const tupleToSources = (
+  {readJsonSync}: Pick<typeof fs, 'readJsonSync'> = fs
+) => (
+  sources: Dict<Source>, [source, sourcePath]: SourceTuple
+) => {
+  const {
+    _from, _resolved, bugs, deprecated, description, homepage, main, peerDependencies
+  } = readJsonSync(Path.join(sourcePath, 'package.json')) as PackageJson;
+
+  sources[sourcePath] = {
+    _from,
+    _resolved,
+    bugs,
+    deprecated,
+    description,
+    docs: source in DOCS ? DOCS[source as keyof typeof DOCS] : 'unknown',
+    homepage,
+    main,
+    name: source,
+    path: sourcePath,
+    peerDependencies
+  };
+  return sources;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,10 +7,11 @@ export type RuleName = {
 
 export type ReportData = {
   documentation?: string;
+  id: string;
   path: string;
   source: string;
   sourcePath: string;
-  sameName?: string[];
+  sameName?: RuleData[]; // TODO generic type or RuleData?
 };
 
 export type RuleMetadata = Partial<IRuleMetadata & ExtendedMetadata> & RuleName;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import {IRuleMetadata, RuleSeverity} from 'tslint';
+import {IRuleMetadata} from 'tslint';
 import {ExtendedMetadata} from './ExtendedMetadata';
 
 export type RuleName = {
@@ -40,14 +40,3 @@ export type Source = PackageJson & {
 
 export type Dict<T> = {[key: string]: T};
 
-export type ActiveRule = RuleName & {
-  deprecated?: string | boolean;
-  documentation?: string;
-  hasFix?: boolean;
-  ruleArguments?: any[];
-  ruleSeverity: RuleSeverity;
-  sameName?: string[];
-  source?: string;
-  group?: string;
-  type?: string;
-};

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,7 @@ export type Source = PackageJson & {
 
 export type Dict<T> = {[key: string]: T};
 
-export type ActiveRule = {
+export type ActiveRule = RuleName & {
   deprecated?: string | boolean;
   documentation?: string;
   hasFix?: boolean;


### PR DESCRIPTION
- some changes in the data structure for for consistent behaviour
  - (unique) id and ruleName are always available
  - detect mismatch of `ruleName` from file name vs metadata (could be error in tslint-report or error in metadata), ignoring value from metadata when different since tslint also resolves rules using file name pattern.
  - before this PR rules with the same name from different rule sets where stored with their id as key and their ids were listed in the `sameName`field. Now they are stored in the `sameName` field directly in the available report, and only their id is listed in the active rules report
- documentation links are now stored in `rules.docs.json`
- extracted code into easily testable methods/modules
- fixes #4 

Changes might be best reviewed commit by commit